### PR TITLE
Start of i18n context implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ env.json
 .serverless
 stack.json
 live_groups.json
-*.json
+package-lock.json
 
 # Webpack directories
 .webpack

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,9 @@
 import { Switch, Route } from 'react-router-dom'
 import React from 'react'
 
+
+import LocaleSwitcher from './components/LocaleSwitcher'
+
 import Groups from './pages/Groups'
 import About from './pages/About'
 
@@ -11,14 +14,17 @@ import Report from './pages/Report'
 
 function App() {
   return (
-    <Switch>
-      <Route path="/about" component={About} />
-      <Route path="/add-group" component={CreateGroup} />
-      <Route path="/edit/:id/:token" component={EditGroup} />
-      <Route path="/edit/:id" component={EmailAuth} />
-      <Route path="/report/:id" component={Report} />
-      <Route path="/" component={Groups} />
-    </Switch>
+    <div>
+      <LocaleSwitcher />
+      <Switch>
+        <Route path="/about" component={About} />
+        <Route path="/add-group" component={CreateGroup} />
+        <Route path="/edit/:id/:token" component={EditGroup} />
+        <Route path="/edit/:id" component={EmailAuth} />
+        <Route path="/report/:id" component={Report} />
+        <Route path="/" component={Groups} />
+      </Switch>
+    </div>
   )
 }
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,17 +14,14 @@ import Report from './pages/Report'
 
 function App() {
   return (
-    <div>
-      <LocaleSwitcher />
-      <Switch>
-        <Route path="/about" component={About} />
-        <Route path="/add-group" component={CreateGroup} />
-        <Route path="/edit/:id/:token" component={EditGroup} />
-        <Route path="/edit/:id" component={EmailAuth} />
-        <Route path="/report/:id" component={Report} />
-        <Route path="/" component={Groups} />
-      </Switch>
-    </div>
+    <Switch>
+      <Route path="/about" component={About} />
+      <Route path="/add-group" component={CreateGroup} />
+      <Route path="/edit/:id/:token" component={EditGroup} />
+      <Route path="/edit/:id" component={EmailAuth} />
+      <Route path="/report/:id" component={Report} />
+      <Route path="/" component={Groups} />
+    </Switch>
   )
 }
 

--- a/client/src/components/EmailsInput.tsx
+++ b/client/src/components/EmailsInput.tsx
@@ -1,12 +1,14 @@
 import CreatableSelect from 'react-select/creatable'
 import { useControl } from './FormControl'
 import React, { useState } from 'react'
+import { useI18n } from '../contexts/I18nProvider'
 
 const EmailsInput = () => {
+  const t = useI18n(locale => locale.translation.components.emails_input)
   const { props } = useControl(
     'emails',
     [],
-    (x) => x.length > 0 || 'Must provide at least one email'
+    (x) => x.length > 0 || t.errors.none_provided
   )
   const [value, setValue] = useState('')
   const [error, setError] = useState('')
@@ -20,7 +22,7 @@ const EmailsInput = () => {
       case ',':
       case 'Tab':
         if (!validEmail(value)) {
-          setError('Must be a valid email address')
+          setError(t.errors.wrong_format)
         } else {
           props.onChange([...props.value, value])
           setValue('')
@@ -43,7 +45,7 @@ const EmailsInput = () => {
         onBlur={() => handleKeyDown({ key: 'Tab' } as any)}
         onInputChange={setValue}
         onKeyDown={handleKeyDown}
-        placeholder="Enter any emails..."
+        placeholder={t.placeholder}
         value={props.value.map((x) => ({ label: x, value: x }))}
       />
       <p style={{ paddingLeft: '1rem', margin: '.4rem 0rem 0rem 0rem', color: 'red' }}>{error}</p>

--- a/client/src/components/GroupFormElements.tsx
+++ b/client/src/components/GroupFormElements.tsx
@@ -6,30 +6,32 @@ import { InputGroup } from '../styles/styles'
 import { useControl } from './FormControl'
 import EmailsInput from './EmailsInput'
 import Location from './Location'
+import { useI18n } from '../contexts/I18nProvider'
 
 const EditGroupForm = ({ disabled }: { disabled?: boolean }) => {
+    const t = useI18n(locale => locale.translation.components.group_form_elements)
   return (
     <div style={{ width: '100%', maxWidth: '30rem' }}>
       <Input
         disabled={disabled}
         name="name"
         init=""
-        valid={(x) => x.length > 0 || 'Must provide a group name'}
-        placeholder="Group name"
+        valid={(x) => x.length > 0 || t.name.errors.none_provided}
+        placeholder={t.name.placeholder}
       />
 
       <Input
         disabled={disabled}
         name="link_facebook"
         init=""
-        valid={(x) => validURL(x) || 'Must provide valid Group URL'}
-        placeholder="https://www.f..."
+        valid={(x) => validURL(x) || t.url.errors.none_provided}
+        placeholder={t.url.placeholder}
       />
 
       <div>
         <Description>
-          Enter any emails for people you want to give access to edit this group{' '}
-          <small style={{ color: 'grey' }}>(These will not be public)</small>
+          {t.emails.description}{' '}
+          <small style={{ color: 'grey' }}>({t.emails.note})</small>
         </Description>
         <EmailsInput />
       </div>
@@ -41,11 +43,11 @@ const EditGroupForm = ({ disabled }: { disabled?: boolean }) => {
       <FormButtons>
         <Link to="/">
           <button className="btn-secondary" type="button" disabled={disabled}>
-            cancel
+              {t.buttons.cancel}
           </button>
         </Link>
         <button type="submit" disabled={disabled}>
-          submit
+            {t.buttons.submit}
         </button>
       </FormButtons>
     </div>

--- a/client/src/components/GroupItem.tsx
+++ b/client/src/components/GroupItem.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import icons, { iconFromUrl } from '../utils/icons'
 import tidyLink from '../utils/tidyLink'
 import { Group } from '../utils/types'
+import {useI18n} from '../contexts/I18nProvider'
 import { useHistory } from 'react-router-dom'
 
 const GroupItem = ({
@@ -17,6 +18,7 @@ const GroupItem = ({
   onSelect: (...args: any[]) => void
   disableDropdown?: boolean
 }) => {
+  const t = useI18n(locale => locale.translation.components.group_item)
   const history = useHistory()
   const [isOpen, setIsOpen] = useState(false)
 
@@ -29,11 +31,11 @@ const GroupItem = ({
       <div className="content">
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
           <h4 onClick={() => onSelect(group.id)}>
-            {group.name === '' ? 'Your group name...' : group.name}
+            {group.name === '' ? t.group_name_prompt : group.name}
           </h4>
         </div>
         <span className="location-name">
-          {group.location_name === '' ? 'Your group location...' : group.location_name}
+          {group.location_name === '' ? t.group_location_prompt : group.location_name}
           {group.distance && group.distance > 0 ? (
             <span className="distance">{(group.distance / 1000).toFixed(1) + 'km'}</span>
           ) : null}

--- a/client/src/components/GroupsList.tsx
+++ b/client/src/components/GroupsList.tsx
@@ -11,7 +11,7 @@ import isIosSafari from '../utils/isIosSafari'
 import GroupItem from './GroupItem'
 
 const GroupsList = ({ closeSidebar }: { closeSidebar: () => void }) => {
-  const  t = useI18n().translation.components.groups_list
+  const  t = useI18n(locale => locale.translation.components.groups_list)
   const [limit, toggleMore] = useReducer((x) => x + 50, 50)
   const { groups } = useData()
   const { onSelect } = usePlaceMethod()

--- a/client/src/components/GroupsList.tsx
+++ b/client/src/components/GroupsList.tsx
@@ -4,12 +4,14 @@ import styled from 'styled-components'
 
 import { usePlaceState, usePlaceMethod } from '../contexts/StateContext'
 import { useData } from '../contexts/DataProvider'
+import { useI18n } from '../contexts/I18nProvider'
 
 import { MOON_BLUE } from '../utils/CONSTANTS'
 import isIosSafari from '../utils/isIosSafari'
 import GroupItem from './GroupItem'
 
 const GroupsList = ({ closeSidebar }: { closeSidebar: () => void }) => {
+  const  t = useI18n().translation.components.groups_list
   const [limit, toggleMore] = useReducer((x) => x + 50, 50)
   const { groups } = useData()
   const { onSelect } = usePlaceMethod()
@@ -54,7 +56,7 @@ const GroupsList = ({ closeSidebar }: { closeSidebar: () => void }) => {
             onClick={toggleMore}
             type="button"
           >
-            load more
+            {t.load_more_prompt}
           </button>
         )}
       </div>

--- a/client/src/components/LocaleSwitcher.tsx
+++ b/client/src/components/LocaleSwitcher.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+import { useI18nSetter } from "../contexts/I18nProvider"
+
+
+const LocaleSwitcher = () => {
+    const setLocale = useI18nSetter()
+    return (
+        <ul>
+            <li><button onClick={() => setLocale("en") }>English</button></li>
+            <li><button onClick={() => setLocale("es") }>Español (Castellano)</button></li>
+        </ul>
+    )
+}
+
+export default LocaleSwitcher

--- a/client/src/components/Location.tsx
+++ b/client/src/components/Location.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import AsyncCreatableSelect from 'react-select/async-creatable'
 import { useRequest } from '../contexts/RequestProvider'
+import { useI18n } from '../contexts/I18nProvider'
 import { useControl } from './FormControl'
 
 let last = ''
@@ -12,13 +13,14 @@ const debounce = (value: string) => {
 }
 
 const Location = () => {
+  const t = useI18n(locale => locale.translation.components.location)
   const request = useRequest()
   const {
     props: { value, onChange: onValue },
   } = useControl(
     'location_name',
     '',
-    (x) => x.length > 0 || 'You must set a location for your group'
+    (x) => x.length > 0 || t.errors.none_provided
   )
   const {
     props: { onChange: onCoords },
@@ -37,7 +39,7 @@ const Location = () => {
           onValue(x.label)
         })
       }
-      placeholder={value || 'e.g "SE14 4NW"'}
+      placeholder={value || t.placeholder }
       loadOptions={(value) =>
         debounce(value)
           .then((val) =>
@@ -51,7 +53,7 @@ const Location = () => {
           })
       }
       backspaceRemoves={true}
-      promptTextCreator={(name: string) => `Location: ${name}`}
+      promptTextCreator={(name: string) => `${t.create_prompt_prefix} ${name}`}
     />
   )
 }

--- a/client/src/components/Nav.tsx
+++ b/client/src/components/Nav.tsx
@@ -6,7 +6,7 @@ import inIframe from '../utils/inIframe'
 import {useI18n} from '../contexts/I18nProvider'
 
 const Nav = ({ children }: { children?: ReactChild }) => {
-  const t = useI18n().translation.components.nav
+  const t = useI18n(locale => locale.translation.components.nav)
   return (
     <NavWrapper>
       <div className="options">

--- a/client/src/components/Nav.tsx
+++ b/client/src/components/Nav.tsx
@@ -3,17 +3,19 @@ import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 import { MOON_BLUE } from '../utils/CONSTANTS'
 import inIframe from '../utils/inIframe'
+import {useI18n} from '../contexts/I18nProvider'
 
 const Nav = ({ children }: { children?: ReactChild }) => {
+  const t = useI18n().translation.components.nav
   return (
     <NavWrapper>
       <div className="options">
         {inIframe() ? (
           <a target="_blank" rel="noopener noreferrer" href="https://mutualaid.wiki">
-            View full site!
+            {t.view_full_site_link}
           </a>
         ) : (
-          <Link to="/about">What is this?</Link>
+          <Link to="/about">{t.information_link}</Link>
         )}
       </div>
       <div className="buttons-right">{children}</div>

--- a/client/src/components/SearchBox.tsx
+++ b/client/src/components/SearchBox.tsx
@@ -6,8 +6,10 @@ import icons from '../utils/icons'
 import { InputGroup } from '../styles/styles'
 import { MOON_BLUE } from '../utils/CONSTANTS'
 import { useData } from '../contexts/DataProvider'
+import { useI18n } from '../contexts/I18nProvider'
 
 const SearchBox = () => {
+  const t = useI18n().translation.components.search_box
   const [searchInput, setSearchInput] = useState('')
   const { onSearch, onSelect } = usePlaceMethod()
   const { search } = usePlaceState()
@@ -28,7 +30,7 @@ const SearchBox = () => {
         <InputGroup>
           <input
             value={searchInput}
-            placeholder="Enter place"
+            placeholder={t.search_prompt}
             onChange={(e) => setSearchInput(e.target.value)}
           />
           <div className="button-group">
@@ -40,7 +42,7 @@ const SearchBox = () => {
       {search.place ? (
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <p style={{ padding: '0 1rem' }}>
-            Showing groups for: <b>{search.place.name}</b>{' '}
+            {t.place_name_label}: <b>{search.place.name}</b>{' '}
             <span
               style={{ color: 'blue', textDecoration: 'underline', cursor: 'pointer' }}
               onClick={() => onSearch()}
@@ -52,7 +54,7 @@ const SearchBox = () => {
       ) : (
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <Link to="/add-group">
-            <p className="add-group">Or add a group</p>
+            <p className="add-group">{t.add_prompt}</p>
           </Link>
         </div>
       )}

--- a/client/src/components/SearchBox.tsx
+++ b/client/src/components/SearchBox.tsx
@@ -9,7 +9,7 @@ import { useData } from '../contexts/DataProvider'
 import { useI18n } from '../contexts/I18nProvider'
 
 const SearchBox = () => {
-  const t = useI18n().translation.components.search_box
+  const t = useI18n(locale => locale.translation.components.search_box)
   const [searchInput, setSearchInput] = useState('')
   const { onSearch, onSelect } = usePlaceMethod()
   const { search } = usePlaceState()

--- a/client/src/components/internationalized/AboutEN.tsx
+++ b/client/src/components/internationalized/AboutEN.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import icons from '../../utils/icons'
+
+const AboutEN = () => {
+  return (
+    <div>
+      <h2>A global map of COVID-19 Mutual Aid groups</h2>
+      <p>
+          Have a list of groups or want to translate this app? Send us an{' '}
+          <a href="mailto:info@mutualaid.wiki">email</a>, we would love to hear from you.
+      </p>
+      <br />
+
+      <p>FAQ:</p>
+      <ul>
+          <li>Can I edit my group info?</li>
+          <p>
+              Yes! Find your group in the sidebar, click the {icons('more')} icon on the top right
+              corner and select edit group from the dropdown. Submit your email and check your inbox
+              for further instructions 🙂.
+          </p>
+          <li>Can I report a group?</li>
+          <p>
+              Yes, click the {icons('more')} icon on the top right corner and select report group from
+              the dropdown. Once you have completed the form, we will review your report and remove
+              the group if we deem it appropriate. We will usually remove the group if it is a link to
+              an individual, spam or promotional, no longer accesible or spreading hate
+              speech/misinformation.
+          </p>
+          <li>Is my personal data safe?</li>
+          <p>
+              While your group information is public, the email addresses you provide are not. We care
+              a lot about privacy and will not disclose this without your written consent.
+          </p>
+          <li>Can you help me find my group?</li>
+          <p>
+              If you send us an email we will do our best to help, but we hope you find this easier
+              after the recent redesign!
+          </p>
+          <li>Why can't I add more information to my group?</li>
+          <p>
+              We are working on this and more. If there is a feature you would really like, please
+              email us or create an issue on{' '}
+              <a href="https://github.com/Covid-Mutual-Aid/groups-map/issues">github</a>
+          </p>
+          <li>Something is broken...</li>
+          <p>
+              Oops, sorry about this. The project is quite young and this does happen from time to
+              time. Would you kindly send us an <a href="mailto:info@mutualaid.wiki">email</a> to let
+              us know or{' '}
+              <a href="https://github.com/Covid-Mutual-Aid/groups-map/issues">create an issue</a>?
+          </p>
+          <li>Who is behind this?</li>
+          <p>
+              We are an open source, volunteer run group of. We also part of the technical team at{' '}
+              <a href="https://covidmutualaid.org">covidmutualaid.org</a>
+          </p>
+      </ul>
+      <br />
+
+      <p>Here is some information you may find useful:</p>
+      <ul>
+          <li>
+              Our email <a href="mailto:info@mutualaid.wiki">info@mutualaid.wiki</a>
+          </li>
+          <li>
+              Our <a href="https://github.com/Covid-Mutual-Aid/groups-map">source code on github</a>
+          </li>
+      </ul>
+      <br />
+      <p>Embed us on your site!</p>
+      <code>{`<iframe src="https://mutualaid.wiki/"></iframe>`}</code>
+      <br />
+      <br />
+      <br />
+
+      <p>
+          With{' '}
+          <span aria-label="heart emoji" role="img">
+              ❤️
+          </span>
+
+      </p>
+      <p>Mutual Aid Wiki team</p>
+    </div>
+  )
+}
+
+export default AboutEN

--- a/client/src/contexts/I18nProvider.tsx
+++ b/client/src/contexts/I18nProvider.tsx
@@ -1,9 +1,19 @@
 import React, { createContext, useContext } from 'react'
 import en from '../locales/en.json'
+import AboutEN from '../components/internationalized/AboutEN'
 
-type Locale = typeof en
+type Translation = typeof en
 
-const defaultState : Locale = en
+class Locale {
+    translation: Translation
+    components: { about: JSX.Element }
+    constructor(translation: Translation, components: { about: JSX.Element }) {
+        this.translation = translation;
+        this.components = components;
+    }
+}
+
+const defaultState : Locale = new Locale(en, { about: <AboutEN /> })
 
 const I18nContext = createContext<Locale>(defaultState)
 

--- a/client/src/contexts/I18nProvider.tsx
+++ b/client/src/contexts/I18nProvider.tsx
@@ -1,8 +1,12 @@
-import React, { createContext, useContext } from 'react'
-import en from '../locales/en.json'
+import React, { createContext, useContext, useState, useMemo } from 'react'
+import enTranslation from '../locales/en.json'
+import esTranslation from '../locales/es.json'
 import AboutEN from '../components/internationalized/AboutEN'
+//import { useParams } from 'react-router-dom'
 
-type Translation = typeof en
+type Translation = typeof enTranslation
+
+
 
 class Locale {
     translation: Translation
@@ -13,21 +17,41 @@ class Locale {
     }
 }
 
-const defaultState : Locale = new Locale(en, { about: <AboutEN /> })
 
-const I18nContext = createContext<Locale>(defaultState)
+const en : Locale = new Locale(enTranslation, { about: <AboutEN /> })
+const es : Locale = new Locale(esTranslation, { about: <AboutEN /> })
+
+
+
+const locales : { [index: string] : Locale } = {
+    "en": en,
+    "es": es
+}
+
+
+const I18nContext = createContext<Locale>(en)
+
+const I18nMethodsContext = createContext<(x : string) => void>((_x) => null)
 
 const I18nProvider = ({ children }: { children: React.ReactNode }) => {
+  const [localeString, setLocale] = useState<string>("en")
+  const locale = locales[localeString] || en
+  const localeCallback = (x : string) => setLocale(x)
   return (
-    <I18nContext.Provider value={defaultState}>
+  <I18nMethodsContext.Provider value={localeCallback}>
+    <I18nContext.Provider value={locale}>
     {children}
     </I18nContext.Provider>
+  </I18nMethodsContext.Provider>
   )
 }
 
 type LocaleTransformer<T> = (v : Locale) => T
+
 export function useI18n<T>(f : LocaleTransformer<T>) : T {
     return f(useContext(I18nContext))
 }
+
+export const useI18nSetter = () => useContext(I18nMethodsContext)
 
 export default I18nProvider

--- a/client/src/contexts/I18nProvider.tsx
+++ b/client/src/contexts/I18nProvider.tsx
@@ -15,5 +15,9 @@ const I18nProvider = ({ children }: { children: React.ReactNode }) => {
   )
 }
 
-export const useI18n = () => useContext(I18nContext)
+type LocaleTransformer<T> = (v : Locale) => T
+export function useI18n<T>(f : LocaleTransformer<T>) : T {
+    return f(useContext(I18nContext))
+}
+
 export default I18nProvider

--- a/client/src/contexts/I18nProvider.tsx
+++ b/client/src/contexts/I18nProvider.tsx
@@ -1,6 +1,5 @@
 import React, { createContext, useContext, useState, useMemo } from 'react'
 import enTranslation from '../locales/en.json'
-import esTranslation from '../locales/es.json'
 import AboutEN from '../components/internationalized/AboutEN'
 //import { useParams } from 'react-router-dom'
 
@@ -19,13 +18,11 @@ class Locale {
 
 
 const en : Locale = new Locale(enTranslation, { about: <AboutEN /> })
-const es : Locale = new Locale(esTranslation, { about: <AboutEN /> })
 
 
 
 const locales : { [index: string] : Locale } = {
     "en": en,
-    "es": es
 }
 
 

--- a/client/src/contexts/I18nProvider.tsx
+++ b/client/src/contexts/I18nProvider.tsx
@@ -1,0 +1,19 @@
+import React, { createContext, useContext } from 'react'
+import en from '../locales/en.json'
+
+type Locale = typeof en
+
+const defaultState : Locale = en
+
+const I18nContext = createContext<Locale>(defaultState)
+
+const I18nProvider = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <I18nContext.Provider value={defaultState}>
+    {children}
+    </I18nContext.Provider>
+  )
+}
+
+export const useI18n = () => useContext(I18nContext)
+export default I18nProvider

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -31,7 +31,7 @@ if (!inIframe()) {
 
 let current = { endpoint: '/api' }
 if ((window as any).location.host.includes('localhost')) {
-  current.endpoint = '/dev'
+  current.endpoint = 'http://mutualaid.wiki/api'
 }
 
 const request = <T extends any>(input: RequestInfo, init?: RequestInit, accum = 0): Promise<T> =>

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -18,6 +18,8 @@ import inIframe from './utils/inIframe'
 import { gtag } from './utils/gtag'
 import App from './App'
 
+import I18nProvider from './contexts/I18nProvider'
+
 Sentry.init({ dsn: 'https://54b6389bc04849729985b907d7dfcffe@sentry.io/5169267' })
 
 if (!inIframe()) {
@@ -43,9 +45,11 @@ const Render = () => (
     <RequestProvider request={request}>
       <DataProvider>
         <StateProvider>
-          <MapProvider>
-            <App />
-          </MapProvider>
+          <I18nProvider>
+            <MapProvider>
+              <App />
+            </MapProvider>
+          </I18nProvider>
         </StateProvider>
       </DataProvider>
     </RequestProvider>

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1,59 +1,57 @@
 {
-  "translation": {
-    "pages": {
-      "groups": {
-        "cta": {
-          "line1": "Find local",
-          "line2": "mutual aid groups"
-        }
-      },
-      "group_form": {
-        "after_submit_message": "Thanks for submitting your group",
-        "complete_cta": "Please complete",
-        "cancel_button": "cancel",
-        "submit_button": "submit"
-      },
-      "email_auth": {
-        "after_submit_message": "Thank you for your request. Please check you email for further instructions",
-        "enter_email_prompt": "Please enter your email",
-        "cancel_button": "Cancel",
-        "submit_button": "submit"
-      },
-      "report": {
-        "after_submit_message": "Thanks for your report",
-        "report_reason_prompt": "Why are you reporting this group?",
-        "report_reason_placeholder": "E.g, it no longer exists...",
-        "cancel_button": "Cancel",
-        "submit_button": "submit"
+  "pages": {
+    "groups": {
+      "cta": {
+        "line1": "Find local",
+        "line2": "mutual aid groups"
       }
     },
-    "components": {
-      "nav": {
-        "information_link": "What's going on?",
-        "view_full_site_link": "View full site!"
-      },
-      "search_box": {
-        "search_prompt": "Enter place",
-        "add_prompt": "Or add a group",
-        "place_name_label": "Showing groups for"
-      },
-      "groups_list": {
-        "load_more_prompt": "load more"
-      },
-      "group_item": {
-        "group_name_prompt": "Your group name...",
-        "group_location_prompt": "Your group location..."
-      },
-      "edit_group_components": {
-        "group_name_label": "Name",
-        "group_name_example": "Group name",
-        "emails_label": "Emails",
-        "email_example": "yourname@mail.com...",
-        "link_label": "Link",
-        "link_example": "http://www...",
-        "location_label": "Location",
-        "location_example": "e.g \"SE14 4NW\""
-      }
+    "group_form": {
+      "after_submit_message": "Thanks for submitting your group",
+      "complete_cta": "Please complete",
+      "cancel_button": "cancel",
+      "submit_button": "submit"
+    },
+    "email_auth": {
+      "after_submit_message": "Thank you for your request. Please check you email for further instructions",
+      "enter_email_prompt": "Please enter your email",
+      "cancel_button": "Cancel",
+      "submit_button": "submit"
+    },
+    "report": {
+      "after_submit_message": "Thanks for your report",
+      "report_reason_prompt": "Why are you reporting this group?",
+      "report_reason_placeholder": "E.g, it no longer exists...",
+      "cancel_button": "Cancel",
+      "submit_button": "submit"
+    }
+  },
+  "components": {
+    "nav": {
+      "information_link": "What's going on?",
+      "view_full_site_link": "View full site!"
+    },
+    "search_box": {
+      "search_prompt": "Enter place",
+      "add_prompt": "Or add a group",
+      "place_name_label": "Showing groups for"
+    },
+    "groups_list": {
+      "load_more_prompt": "load more"
+    },
+    "group_item": {
+      "group_name_prompt": "Your group name...",
+      "group_location_prompt": "Your group location..."
+    },
+    "edit_group_components": {
+      "group_name_label": "Name",
+      "group_name_example": "Group name",
+      "emails_label": "Emails",
+      "email_example": "yourname@mail.com...",
+      "link_label": "Link",
+      "link_example": "http://www...",
+      "location_label": "Location",
+      "location_example": "e.g \"SE14 4NW\""
     }
   }
 }

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -43,15 +43,41 @@
       "group_name_prompt": "Your group name...",
       "group_location_prompt": "Your group location..."
     },
-    "edit_group_components": {
-      "group_name_label": "Name",
-      "group_name_example": "Group name",
-      "emails_label": "Emails",
-      "email_example": "yourname@mail.com...",
-      "link_label": "Link",
-      "link_example": "http://www...",
-      "location_label": "Location",
-      "location_example": "e.g \"SE14 4NW\""
+    "emails_input": {
+      "errors": {
+        "none_provided": "Must provide at least one email",
+        "wrong_format": "Must be a valid email address"
+      },
+      "placeholder": "Enter any emails..."
+    },
+    "group_form_elements": {
+      "name" : {
+        "placeholder": "Group name",
+        "errors": {
+          "none_provided": "Must provide a group name"
+        }
+      },
+      "url" : {
+        "placeholder": "https://www.f...",
+        "errors": {
+          "none_provided": "Must provide a valid Group URL"
+        }
+      },
+      "emails": {
+        "description": "Enter any emails for people you want to give access to edit this group",
+        "note": "These will not be public"
+      },
+      "buttons": {
+        "cancel": "cancel",
+        "submit": "submit"
+      }
+    },
+    "location": {
+      "placeholder": "e.g. \"SE14 4NW\"",
+      "create_prompt_prefix": "Location:",
+      "errors": {
+        "none_provided": "You must set a location for your group"
+      }
     }
   }
 }

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1,0 +1,26 @@
+{
+  "translation": {
+    "pages": {
+      "groups": {
+        "cta": {
+          "line1": "Find local",
+          "line2": "mutual aid groups"
+        }
+      }
+    },
+    "components": {
+      "nav": {
+        "information_link": "INFORMATION",
+        "help_link": "?"
+      },
+      "search_box": {
+        "search_prompt": "Enter place",
+        "add_prompt": "Or add a group",
+        "place_name_label": "Showing groups for"
+      },
+      "groups_list": {
+        "load_more_prompt": "load more"
+      }
+    }
+  }
+}

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -10,8 +10,8 @@
     },
     "components": {
       "nav": {
-        "information_link": "INFORMATION",
-        "help_link": "?"
+        "information_link": "What's going on?",
+        "view_full_site_link": "View full site!"
       },
       "search_box": {
         "search_prompt": "Enter place",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -6,6 +6,25 @@
           "line1": "Find local",
           "line2": "mutual aid groups"
         }
+      },
+      "group_form": {
+        "after_submit_message": "Thanks for submitting your group",
+        "complete_cta": "Please complete",
+        "cancel_button": "cancel",
+        "submit_button": "submit"
+      },
+      "email_auth": {
+        "after_submit_message": "Thank you for your request. Please check you email for further instructions",
+        "enter_email_prompt": "Please enter your email",
+        "cancel_button": "Cancel",
+        "submit_button": "submit"
+      },
+      "report": {
+        "after_submit_message": "Thanks for your report",
+        "report_reason_prompt": "Why are you reporting this group?",
+        "report_reason_placeholder": "E.g, it no longer exists...",
+        "cancel_button": "Cancel",
+        "submit_button": "submit"
       }
     },
     "components": {
@@ -24,6 +43,16 @@
       "group_item": {
         "group_name_prompt": "Your group name...",
         "group_location_prompt": "Your group location..."
+      },
+      "edit_group_components": {
+        "group_name_label": "Name",
+        "group_name_example": "Group name",
+        "emails_label": "Emails",
+        "email_example": "yourname@mail.com...",
+        "link_label": "Link",
+        "link_example": "http://www...",
+        "location_label": "Location",
+        "location_example": "e.g \"SE14 4NW\""
       }
     }
   }

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -20,6 +20,10 @@
       },
       "groups_list": {
         "load_more_prompt": "load more"
+      },
+      "group_item": {
+        "group_name_prompt": "Your group name...",
+        "group_location_prompt": "Your group location..."
       }
     }
   }

--- a/client/src/pages/About.tsx
+++ b/client/src/pages/About.tsx
@@ -2,8 +2,10 @@ import React from 'react'
 import styled from 'styled-components'
 import icons from '../utils/icons'
 import { Link } from 'react-router-dom'
+import { useI18n } from '../contexts/I18nProvider'
 
 const AboutPage = () => {
+  const aboutInformation = useI18n(locale => locale.components.about)
   return (
     <Center>
       <Content>
@@ -15,84 +17,7 @@ const AboutPage = () => {
         <br />
         <br />
         <br />
-        <h2>A global map of COVID-19 Mutual Aid groups</h2>
-        <p>
-          Have a list of groups or want to translate this app? Send us an{' '}
-          <a href="mailto:info@mutualaid.wiki">email</a>, we would love to hear from you.
-        </p>
-        <br />
-
-        <p>FAQ:</p>
-        <ul>
-          <li>Can I edit my group info?</li>
-          <p>
-            Yes! Find your group in the sidebar, click the {icons('more')} icon on the top right
-            corner and select edit group from the dropdown. Submit your email and check your inbox
-            for further instructions 🙂.
-          </p>
-          <li>Can I report a group?</li>
-          <p>
-            Yes, click the {icons('more')} icon on the top right corner and select report group from
-            the dropdown. Once you have completed the form, we will review your report and remove
-            the group if we deem it appropriate. We will usually remove the group if it is a link to
-            an individual, spam or promotional, no longer accesible or spreading hate
-            speech/misinformation.
-          </p>
-          <li>Is my personal data safe?</li>
-          <p>
-            While your group information is public, the email addresses you provide are not. We care
-            a lot about privacy and will not disclose this without your written consent.
-          </p>
-          <li>Can you help me find my group?</li>
-          <p>
-            If you send us an email we will do our best to help, but we hope you find this easier
-            after the recent redesign!
-          </p>
-          <li>Why can't I add more information to my group?</li>
-          <p>
-            We are working on this and more. If there is a feature you would really like, please
-            email us or create an issue on{' '}
-            <a href="https://github.com/Covid-Mutual-Aid/groups-map/issues">github</a>
-          </p>
-          <li>Something is broken...</li>
-          <p>
-            Oops, sorry about this. The project is quite young and this does happen from time to
-            time. Would you kindly send us an <a href="mailto:info@mutualaid.wiki">email</a> to let
-            us know or{' '}
-            <a href="https://github.com/Covid-Mutual-Aid/groups-map/issues">create an issue</a>?
-          </p>
-          <li>Who is behind this?</li>
-          <p>
-            We are an open source, volunteer run group of. We also part of the technical team at{' '}
-            <a href="https://covidmutualaid.org">covidmutualaid.org</a>
-          </p>
-        </ul>
-        <br />
-
-        <p>Here is some information you may find useful:</p>
-        <ul>
-          <li>
-            Our email <a href="mailto:info@mutualaid.wiki">info@mutualaid.wiki</a>
-          </li>
-          <li>
-            Our <a href="https://github.com/Covid-Mutual-Aid/groups-map">source code on github</a>
-          </li>
-        </ul>
-        <br />
-        <p>Embed us on your site!</p>
-        <code>{`<iframe src="https://mutualaid.wiki/"></iframe>`}</code>
-        <br />
-        <br />
-        <br />
-
-        <p>
-          With{' '}
-          <span aria-label="heart emoji" role="img">
-            ❤️
-          </span>
-          ,
-        </p>
-        <p>Mutual Aid Wiki team</p>
+        {aboutInformation}
         <br />
         <br />
         <br />

--- a/client/src/pages/EmailAuth.tsx
+++ b/client/src/pages/EmailAuth.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { InputGroup } from '../styles/styles'
 import { useRequest } from '../contexts/RequestProvider'
+import { useI18n } from '../contexts/I18nProvider'
 import styled from 'styled-components'
 import { Link, useParams, useHistory } from 'react-router-dom'
 
@@ -11,12 +12,13 @@ const EmailAuth = () => {
   const [error, setError] = useState<string | null>(null)
   const [sucessModal, setSucessModal] = useState(false)
   const request = useRequest()
+  const t = useI18n(locale => locale.translation.pages.email_auth)
 
   return (
     <Wrapper>
       {sucessModal ? (
         <div style={{ textAlign: 'center', padding: '4rem', color: '#28a745' }}>
-          <h3>Thank you for your request. Please check you email for further instructions</h3>
+          <h3>{ t.after_submit_message }</h3>
         </div>
       ) : (
         <form
@@ -37,14 +39,14 @@ const EmailAuth = () => {
               .then(() => history.replace('/'))
           }}
         >
-          <h4>Please enter your email</h4>
+          <h4>{ t.enter_email_prompt }</h4>
           <InputGroup>
             <input value={email} onChange={(e) => setEmail(e.target.value)} />
-            <button type="submit">submit</button>
+            <button type="submit">{ t.submit_button }</button>
           </InputGroup>
           <div className="cancel">
             <Link to="/">
-              <button className="btn-secondary">Cancel</button>
+              <button className="btn-secondary">{ t.cancel_button }</button>
             </Link>
           </div>
           <p style={{ color: 'red' }}>{error}</p>

--- a/client/src/pages/Groups.tsx
+++ b/client/src/pages/Groups.tsx
@@ -15,7 +15,7 @@ import { useI18n } from '../contexts/I18nProvider'
 
 const NewLayout = () => {
   const [open, setOpen] = useState(true)
-  const t = useI18n().translation.pages.groups
+  const t = useI18n(locale => locale.translation.pages.groups)
   return (
     <LayoutStyles className="new-layout" sidebar={open}>
       <div className="side-bar">

--- a/client/src/pages/Groups.tsx
+++ b/client/src/pages/Groups.tsx
@@ -11,8 +11,11 @@ import icons from '../utils/icons'
 import Nav from '../components/Nav'
 import inIframe from '../utils/inIframe'
 
+import { useI18n } from '../contexts/I18nProvider'
+
 const NewLayout = () => {
   const [open, setOpen] = useState(true)
+  const t = useI18n().translation.pages.groups
   return (
     <LayoutStyles className="new-layout" sidebar={open}>
       <div className="side-bar">
@@ -37,7 +40,7 @@ const NewLayout = () => {
               <div style={{ height: '1rem' }}></div>
             ) : (
               <h3>
-                Find local COVID-19 <br className="break" /> mutual aid groups
+                { t.cta.line1 } <br className="break" /> { t.cta.line2 }
               </h3>
             )}
           </div>

--- a/client/src/pages/Report.tsx
+++ b/client/src/pages/Report.tsx
@@ -4,6 +4,7 @@ import { Link, useParams, useHistory } from 'react-router-dom'
 
 import { ValidatedInput } from '../components/ValidatedInput'
 import { useRequest } from '../contexts/RequestProvider'
+import { useI18n } from '../contexts/I18nProvider'
 
 const Report = () => {
   const [successModal, setSuccessModal] = useState(false)
@@ -13,12 +14,12 @@ const Report = () => {
   const { id } = useParams<{ id: string }>()
   const history = useHistory()
   const request = useRequest()
-
+  const t = useI18n(locale => locale.translation.pages.report)
   return (
     <CenterAlign>
       {successModal ? (
         <div style={{ textAlign: 'center', padding: '4rem', color: '#28a745' }}>
-          <h3>Thanks for your report</h3>
+          <h3>{ t.after_submit_message }</h3>
         </div>
       ) : (
         <form
@@ -36,10 +37,10 @@ const Report = () => {
               .then(() => history.replace('/'))
           }}
         >
-          <p>Why are you reporting this group?</p>
+          <p>{ t.report_reason_prompt }</p>
           <InputGroup>
             <ValidatedInput
-              placeholder="E.g, it no longer exists..."
+              placeholder={t.report_reason_placeholder}
               value={message}
               onChange={({ value, validated }) => {
                 setMessage(value)
@@ -51,10 +52,10 @@ const Report = () => {
           <FormButtons>
             <Link to="/">
               <button className="btn-secondary" type="button">
-                cancel
+                { t.cancel_button }
               </button>
             </Link>
-            <button type="submit">submit</button>
+            <button type="submit">{ t.submit_button }</button>
           </FormButtons>
         </form>
       )}


### PR DESCRIPTION
Hi there folks - here's the outline of a Context / Provider pattern implementation of the i18n stuff - I've edited the 'Groups' page component to show how it could be used in practice.

One neat thing about this approach over the library (thanks, @Pingid for the idea) is that referencing UI copy is now typesafe (ie if you try and reference copy that's not written we'll get a type error), and once we add translations, checking them for completeness is also handled by the type checker, which is pretty cool.

I'd be keen on any feedback on my approach - next steps are probably to integrate use of the i18n context for copy elsewhere on the site, create a Spanish translation, and then to look into producing a UI component for a language switcher (I'm guessing this'd roughly follow the pattern set out in `MapProvider.tsx` for updates to the MapContext from the map controls), if that makes sense.

cheers!

Tim
